### PR TITLE
Fix bug in cv::shape::AffineTransformer

### DIFF
--- a/modules/shape/src/aff_trans.cpp
+++ b/modules/shape/src/aff_trans.cpp
@@ -163,8 +163,8 @@ static Mat _localAffineEstimate(const std::vector<Point2f>& shape1, const std::v
             }
             else
             {
-                therow.at<float>(0,0)=-shape1[contPt].y;
-                therow.at<float>(0,1)=shape1[contPt].x;
+                therow.at<float>(0,0)=shape1[contPt].y;
+                therow.at<float>(0,1)=-shape1[contPt].x;
                 therow.at<float>(0,3)=1;
                 therow.row(0).copyTo(matM.row(ii));
                 matP.at<float>(ii,0) = shape2[contPt].y;


### PR DESCRIPTION
When the fullAffine parameter is set to false, the estimateRigidTransform function maybe return empty, then the _localAffineEstimate function will be called, but the bug in it will result in incorrect results.

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
